### PR TITLE
Ruller tilbake flyway til 11.12.0 etter at det feilet i dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ val vaultJdbcVersion = "1.3.10"
 val orgJsonVersion = "20260522"
 val nettyVersion = "4.2.15.Final"
 
-
 // Test avhengigheter
 val junitJupiterVersion = "6.1.1"
 val junitPlatformVersion = "6.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 val k9rapidVersion = "1.20260630092344-01f2f22"
-val flywayVersion = "12.10.0"
+val flywayVersion = "11.12.0"
 val hikariVersion = "7.1.0"
 val kotliqueryVersion = "1.9.1"
 val postgresVersion = "42.7.12"
@@ -10,6 +10,7 @@ val dusseldorfVersion = "8.0.2"
 val vaultJdbcVersion = "1.3.10"
 val orgJsonVersion = "20260522"
 val nettyVersion = "4.2.15.Final"
+
 
 // Test avhengigheter
 val junitJupiterVersion = "6.1.1"


### PR DESCRIPTION
### Behov / Bakgrunn
Feiler i dev: java.lang.NullPointerException: Cannot invoke "org.flywaydb.core.internal.proprietaryStubs.DryRunConfigurationExtensionStub.getOrResolveOutputStream(String, org.flywaydb.core.api.configuration.Configuration)" because the return value of "org.flywaydb.core.internal.plugin.PluginRegister.getInstanceOf(java.lang.Class)" is null

### Løsning
Rull tilbake flyway

### Andre endringer

